### PR TITLE
Feat custom dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,5 @@
 # T-Mobile Coding Challenge
 
-### Important! Read this First !
-
-Do **not** submit a pull request to this repository.  You PR wil be rejected and your submission ignored.
-To be safe **do not Fork** this repository, if you do you will be tempted to create a PR.
-
-To _properly_ submit a coding challenge you must:
-
-1. Create a blank (empty) repo in the public git service of your choice ( github, gitlab, bitbucket )
-2. Clone this repo to your local workstation
-3. Reset the remote origin to point to your newly created empty repo
-4. Push the master branch up to your repo
-
-5. make necessary changes
-6. push changes to your origin
-7. send address of your copy to t-mobile.
-
-We will review your copy online before and during your interview.
-
-
-# Stocks coding challenge
-
-## How to run the application
-
-There are two apps: `stocks` and `stocks-api`.
-
-- `stocks` is the front-end. It uses Angular 7 and Material. You can run this using `yarn serve:stocks`
-- `stocks-api` uses Hapi and has a very minimal implementation. You can start the API server with `yarn serve:stocks-api`
-
-A proxy has been set up in `stocks` to proxy calls to `locahost:3333` which is the port that the Hapi server listens on.
-
-> You need to register for a token here: https://iexcloud.io/cloud-login#/register/ Use this token in the `environment.ts` file for the `stocks` app.
-
-> The charting library is the Google charts API: https://developers.google.com/chart/
-
-## Problem statement
-
-[Original problem statement](https://github.com/tmobile/developer-kata/blob/master/puzzles/web-api/stock-broker.md)
-
-### Task 1
-
-Please provide a short code review of the base `master` branch:
-
-1. What is done well?
-2. What would you change?
-3. Are there any code smells or problematic implementations?
-
-> Make a PR to fix at least one of the issues that you identify
-
-### Task 2
-
-```
-Business requirement: As a user I should be able to type into
-the symbol field and make a valid time-frame selection so that
-the graph is refreshed automatically without needing to click a button.
-```
-
-_**Make a PR from the branch `feat_stock_typeahead` to `master` and provide a code review on this PR**_
-
-> Add comments to the PR. Focus on all items that you can see - this is a hypothetical example but let's treat it as a critical application. Then present these changes as another commit on the PR.
-
 ### Task 3
 
 ```
@@ -73,14 +13,13 @@ _**Implement this feature and make a PR from the branch `feat_custom_dates` to `
 
 > We need two date-pickers: "from" and "to". The date-pickers should not allow selection of dates after the current day. "to" cannot be before "from" (selecting an invalid range should make both dates the same value)
 
-### Task 4
+_**Note: Added only the minimal changes to complete the business requirement. Changes with `util` and test case fixes were done in Task 1**_
 
-```
-Technical requirement: the server `stocks-api` should be used as a proxy
-to make calls. Calls should be cached in memory to avoid querying for the
-same data. If a query is not in cache we should call-through to the API.
-```
+_Task 1 PR: https://github.com/ASreedh1/TMO-dev-puzzle/pull/1_
 
-_**Implement the solution and make a PR from the branch `feat_proxy_server` to `master`**_
+### Changes done
 
-> It is important to get the implementation working before trying to organize and clean it up.
+- Added the Angular material date picker and form validation error.
+- Added logic to transform date range to periods available in API.
+- Used `dataChange` event of `mat-datepicker` to reset date when date "to" before "from".
+- Fixed the unit test case for Stock component.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ _Task 1 PR: https://github.com/ASreedh1/TMO-dev-puzzle/pull/1_
 ### Changes done
 
 - Added the Angular material date picker and form validation error.
-- Added logic to transform date range to periods available in API.
-- Used `dataChange` event of `mat-datepicker` to reset date when date "to" before "from".
-- Fixed the unit test case for Stock component.
+- Always pass `period` as `max` to IEX API, so that filtering can be applied to any dates within the last 5 years (limitation: date range cannot be passed to API and gives only last 5 year data).
+- Used `dataChange` event of mat-datepicker to reset date when date selected is "to" before "from" or "from" after "to".- Fixed the bug to show the chart.
+- Added / fixed the unit test case for Stock component.

--- a/apps/stocks/src/environments/environment.ts
+++ b/apps/stocks/src/environments/environment.ts
@@ -6,7 +6,7 @@ import { StocksAppConfig } from '@coding-challenge/stocks/data-access-app-config
 
 export const environment: StocksAppConfig = {
   production: false,
-  apiKey: '',
+  apiKey: 'Tsk_3fb186a8f9ca40fa9e06c87cecf2cc7a',
   apiURL: 'https://sandbox.iexapis.com'
 };
 

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,8 +1,8 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="data && data.length > 0"
   [title]="chart.title"
   [type]="chart.type"
-  [data]="chartData"
+  [data]="data"
   [columnNames]="chart.columnNames"
   [options]="chart.options"
 >

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.ts
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.ts
@@ -13,7 +13,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./chart.component.css']
 })
 export class ChartComponent implements OnInit {
-  @Input() data$: Observable<any>;
+  @Input() data: any;
   chartData: any;
 
   chart: {
@@ -33,7 +33,5 @@ export class ChartComponent implements OnInit {
       columnNames: ['period', 'close'],
       options: { title: `Stock price`, width: '600', height: '400' }
     };
-
-    this.data$.subscribe(newData => (this.chartData = newData));
   }
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
@@ -1,6 +1,6 @@
 import { PriceQueryResponse, PriceQuery } from './price-query.type';
 import { map, pick } from 'lodash-es';
-import { parse, differenceInMonths, differenceInYears } from 'date-fns';
+import { parse } from 'date-fns';
 import { FetchPriceQuery } from './price-query.actions';
 
 export function transformPriceQueryResponse(

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
@@ -1,6 +1,7 @@
 import { PriceQueryResponse, PriceQuery } from './price-query.type';
 import { map, pick } from 'lodash-es';
 import { parse, differenceInMonths, differenceInYears } from 'date-fns';
+import { FetchPriceQuery } from './price-query.actions';
 
 export function transformPriceQueryResponse(
   response: PriceQueryResponse[]
@@ -53,4 +54,12 @@ export function transformDateRangeToTimePeriod(dateFrom: Date, dateTo: Date) {
     default:
       return '1m';
   }
+}
+
+export function filterPriceQueryResponse(resp: any[], action: FetchPriceQuery) {
+  return resp.filter(
+    (data: PriceQueryResponse) =>
+      parse(data.date) >= parse(action.dateFrom) &&
+      parse(data.date) <= parse(action.dateTo)
+  );
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
@@ -27,34 +27,9 @@ export function transformPriceQueryResponse(
   );
 }
 
-/**
- * Since API doesn't support dates, transform the dates to periods available in API
- */
-export function transformDateRangeToTimePeriod(dateFrom: Date, dateTo: Date) {
-  const diffInYears = differenceInYears(dateTo, dateFrom);
-  switch (true) {
-    case diffInYears >= 5:
-      return 'max';
-    case diffInYears >= 2:
-      return '5y';
-    case diffInYears >= 1:
-      return '2y';
-    case diffInYears > 0:
-      return '1y';
-  }
-
-  const diffInMonths = differenceInMonths(dateTo, dateFrom);
-  switch (true) {
-    case diffInMonths >= 1:
-      return '3m';
-    case diffInMonths >= 3:
-      return '6m';
-    case diffInMonths >= 6:
-      return '1y';
-    default:
-      return '1m';
-  }
-}
+export const timePeriod = {
+  MAX: 'max'
+};
 
 export function filterPriceQueryResponse(resp: any[], action: FetchPriceQuery) {
   return resp.filter(

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
@@ -1,6 +1,6 @@
 import { PriceQueryResponse, PriceQuery } from './price-query.type';
 import { map, pick } from 'lodash-es';
-import { parse } from 'date-fns';
+import { parse, differenceInMonths, differenceInYears } from 'date-fns';
 
 export function transformPriceQueryResponse(
   response: PriceQueryResponse[]
@@ -24,4 +24,33 @@ export function transformPriceQueryResponse(
         dateNumeric: parse(responseItem.date).getTime()
       } as PriceQuery)
   );
+}
+
+/**
+ * Since API doesn't support dates, transform the dates to periods available in API
+ */
+export function transformDateRangeToTimePeriod(dateFrom: Date, dateTo: Date) {
+  const diffInYears = differenceInYears(dateTo, dateFrom);
+  switch (true) {
+    case diffInYears >= 5:
+      return 'max';
+    case diffInYears >= 2:
+      return '5y';
+    case diffInYears >= 1:
+      return '2y';
+    case diffInYears > 0:
+      return '1y';
+  }
+
+  const diffInMonths = differenceInMonths(dateTo, dateFrom);
+  switch (true) {
+    case diffInMonths >= 1:
+      return '3m';
+    case diffInMonths >= 3:
+      return '6m';
+    case diffInMonths >= 6:
+      return '1y';
+    default:
+      return '1m';
+  }
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query-transformer.util.ts
@@ -1,6 +1,6 @@
 import { PriceQueryResponse, PriceQuery } from './price-query.type';
 import { map, pick } from 'lodash-es';
-import { parse } from 'date-fns';
+import { parse, differenceInYears } from 'date-fns';
 import { FetchPriceQuery } from './price-query.actions';
 
 export function transformPriceQueryResponse(
@@ -27,9 +27,26 @@ export function transformPriceQueryResponse(
   );
 }
 
-export const timePeriod = {
-  MAX: 'max'
-};
+export function transformDateRangeToTimePeriod(dateFrom: Date, dateTo: Date) {
+  const dateToday = new Date();
+
+  // if to date less than today's date, take difference between current date and date from
+  if (dateTo < dateToday) {
+    dateTo = dateToday;
+  }
+
+  const diffInYears = differenceInYears(dateTo, dateFrom);
+  switch (true) {
+    case diffInYears >= 5:
+      return 'max';
+    case diffInYears >= 2:
+      return '5y';
+    case diffInYears >= 1:
+      return '2y';
+    default:
+      return '1y';
+  }
+}
 
 export function filterPriceQueryResponse(resp: any[], action: FetchPriceQuery) {
   return resp.filter(

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.actions.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.actions.ts
@@ -10,7 +10,11 @@ export enum PriceQueryActionTypes {
 
 export class FetchPriceQuery implements Action {
   readonly type = PriceQueryActionTypes.FetchPriceQuery;
-  constructor(public symbol: string, public period: string) {}
+  constructor(
+    public symbol: string,
+    public dateFrom: Date,
+    public dateTo: Date
+  ) {}
 }
 
 export class PriceQueryFetchError implements Action {

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -15,7 +15,10 @@ import {
 } from './price-query.actions';
 import { PriceQueryPartialState } from './price-query.reducer';
 import { PriceQueryResponse } from './price-query.type';
-import { transformDateRangeToTimePeriod } from './price-query-transformer.util';
+import {
+  transformDateRangeToTimePeriod,
+  filterPriceQueryResponse
+} from './price-query-transformer.util';
 
 @Injectable()
 export class PriceQueryEffects {
@@ -36,7 +39,7 @@ export class PriceQueryEffects {
           .pipe(
             map(
               (resp: any[]) =>
-                new PriceQueryFetched(this.filterPriceQueryResponse(
+                new PriceQueryFetched(filterPriceQueryResponse(
                   resp,
                   action
                 ) as PriceQueryResponse[])
@@ -55,21 +58,4 @@ export class PriceQueryEffects {
     private httpClient: HttpClient,
     private dataPersistence: DataPersistence<PriceQueryPartialState>
   ) {}
-
-  /**
-   * Filter the price query response
-   * Fixes the chart issue if same from and to date selected
-   * Since new Date and action.date give different date value for hh:mm:ss
-   */
-  private filterPriceQueryResponse(resp: any[], action: FetchPriceQuery) {
-    return resp.filter(
-      (data: PriceQueryResponse) =>
-        (new Date(data.date) >= action.dateFrom &&
-          new Date(data.date) <= action.dateTo) ||
-        (new Date(data.date).toDateString() ===
-          action.dateFrom.toDateString() &&
-          new Date(data.date).toDateString() === action.dateTo.toDateString() &&
-          action.dateFrom.toDateString() === action.dateTo.toDateString())
-    );
-  }
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -16,7 +16,7 @@ import {
 import { PriceQueryPartialState } from './price-query.reducer';
 import { PriceQueryResponse } from './price-query.type';
 import {
-  transformDateRangeToTimePeriod,
+  timePeriod,
   filterPriceQueryResponse
 } from './price-query-transformer.util';
 
@@ -26,15 +26,11 @@ export class PriceQueryEffects {
     PriceQueryActionTypes.FetchPriceQuery,
     {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
-        const period = transformDateRangeToTimePeriod(
-          action.dateFrom,
-          action.dateTo
-        );
         return this.httpClient
           .get(
-            `${this.env.apiURL}/beta/stock/${
-              action.symbol
-            }/chart/${period}?token=${this.env.apiKey}`
+            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
+              timePeriod.MAX
+            }?token=${this.env.apiKey}`
           )
           .pipe(
             map(

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -16,8 +16,8 @@ import {
 import { PriceQueryPartialState } from './price-query.reducer';
 import { PriceQueryResponse } from './price-query.type';
 import {
-  timePeriod,
-  filterPriceQueryResponse
+  filterPriceQueryResponse,
+  transformDateRangeToTimePeriod
 } from './price-query-transformer.util';
 
 @Injectable()
@@ -26,11 +26,15 @@ export class PriceQueryEffects {
     PriceQueryActionTypes.FetchPriceQuery,
     {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
+        const period = transformDateRangeToTimePeriod(
+          action.dateFrom,
+          action.dateTo
+        );
         return this.httpClient
           .get(
-            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
-              timePeriod.MAX
-            }?token=${this.env.apiKey}`
+            `${this.env.apiURL}/beta/stock/${
+              action.symbol
+            }/chart/${period}?token=${this.env.apiKey}`
           )
           .pipe(
             map(

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.facade.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.facade.ts
@@ -18,7 +18,7 @@ export class PriceQueryFacade {
 
   constructor(private store: Store<PriceQueryPartialState>) {}
 
-  fetchQuote(symbol: string, period: string) {
-    this.store.dispatch(new FetchPriceQuery(symbol, period));
+  fetchQuote(symbol: string, dateFrom: Date, dateTo: Date) {
+    this.store.dispatch(new FetchPriceQuery(symbol, dateFrom, dateTo));
   }
 }

--- a/libs/stocks/feature-shell/src/lib/stocks-feature-shell.module.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks-feature-shell.module.ts
@@ -4,7 +4,9 @@ import {
   MatFormFieldModule,
   MatInputModule,
   MatSelectModule,
-  MatButtonModule
+  MatButtonModule,
+  MatDatepickerModule,
+  MatNativeDateModule
 } from '@angular/material';
 import { RouterModule } from '@angular/router';
 import { SharedUiChartModule } from '@coding-challenge/shared/ui/chart';
@@ -22,6 +24,8 @@ import { ReactiveFormsModule } from '@angular/forms';
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     SharedUiChartModule
   ],
   declarations: [StocksComponent]

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
@@ -1,11 +1,6 @@
 <form [formGroup]="stockPickerForm">
   <mat-form-field>
-    <input
-      matInput
-      placeholder="Symbol e.g AAPL"
-      formControlName="symbol"
-      value=""
-    />
+    <input matInput placeholder="Symbol e.g AAPL" formControlName="symbol" />
     <mat-error
       ><span
         *ngIf="
@@ -16,20 +11,53 @@
       >
     </mat-error>
   </mat-form-field>
+  <mat-form-field>
+    <input
+      matInput
+      [matDatepicker]="dateFrom"
+      placeholder="Choose a start date"
+      [min]="date.minFromDate"
+      [max]="date.maxFromDate"
+      formControlName="dateFrom"
+      (dateChange)="resetDate()"
+    />
+    <mat-datepicker-toggle matSuffix [for]="dateFrom"></mat-datepicker-toggle>
+    <mat-error
+      ><span
+        *ngIf="
+          !stockPickerForm.get('dateFrom').valid &&
+          stockPickerForm.get('dateFrom').touched
+        "
+        >Please choose the start date</span
+      >
+    </mat-error>
+    <mat-datepicker touchUi #dateFrom></mat-datepicker>
+  </mat-form-field>
 
   <mat-form-field>
-    <mat-label>Favorite time period</mat-label>
-    <mat-select formControlName="period">
-      <mat-option
-        *ngFor="let timePeriod of timePeriods"
-        [value]="timePeriod.value"
+    <input
+      matInput
+      [matDatepicker]="dateTo"
+      placeholder="Choose an end date"
+      [min]="date.minToDate"
+      [max]="date.maxToDate"
+      formControlName="dateTo"
+      (dateChange)="resetDate()"
+    />
+    <mat-datepicker-toggle matSuffix [for]="dateTo"></mat-datepicker-toggle>
+    <mat-error
+      ><span
+        *ngIf="
+          !stockPickerForm.get('dateTo').valid &&
+          stockPickerForm.get('dateTo').touched
+        "
+        >Please choose the end date</span
       >
-        {{ timePeriod.viewValue }}
-      </mat-option>
-    </mat-select>
+    </mat-error>
+    <mat-datepicker touchUi #dateTo></mat-datepicker>
   </mat-form-field>
 
   <button (click)="fetchQuote()" mat-raised-button>Go</button>
 </form>
 
-<coding-challenge-chart [data$]="quotes$"></coding-challenge-chart>
+<coding-challenge-chart [data]="quotes$ | async"></coding-challenge-chart>

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.spec.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.spec.ts
@@ -1,25 +1,116 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { StocksComponent } from './stocks.component';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { PriceQueryFacade } from '@coding-challenge/stocks/data-access-price-query';
+import {
+  MatFormFieldModule,
+  MatInputModule,
+  MatSelectModule,
+  MatButtonModule,
+  MatDatepickerModule,
+  MatNativeDateModule
+} from '@angular/material';
+import { SharedUiChartModule } from '@coding-challenge/shared/ui/chart';
+import { StoreModule } from '@ngrx/store';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+const MockPriceQueryFacade = {
+  error$: of({
+    value: 'error'
+  }),
+  fetchQuote: jest.fn(),
+  loadSymbol: jest.fn()
+};
 
 describe('StocksComponent', () => {
   let component: StocksComponent;
   let fixture: ComponentFixture<StocksComponent>;
+  const formBuilder: FormBuilder = new FormBuilder();
+  let priceQuery: PriceQueryFacade;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ StocksComponent ]
-    })
-    .compileComponents();
+      declarations: [StocksComponent],
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatButtonModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        SharedUiChartModule,
+        StoreModule.forRoot({})
+      ],
+      providers: [
+        {
+          provide: PriceQueryFacade,
+          useValue: MockPriceQueryFacade
+        }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StocksComponent);
     component = fixture.componentInstance;
+    priceQuery = TestBed.get(PriceQueryFacade);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call stockLoad()', () => {
+    spyOn(component as any, 'stockLoad');
+    component.ngOnInit();
+    expect((component as any).stockLoad).toBeCalled();
+  });
+
+  it('should call createStockPickerForm()', () => {
+    spyOn(component as any, 'createStockPickerForm');
+    (component as any).stockLoad();
+    expect((component as any).createStockPickerForm).toBeCalled();
+  });
+
+  it('should call resetDate() and dateFrom > dateTo', () => {
+    (component as any).stockPickerForm = formBuilder.group({
+      symbol: 'AAPL',
+      dateFrom: '1/14/2019',
+      dateTo: '1/14/2020'
+    });
+
+    (component as any).stockPickerForm.controls.dateTo.patchValue('1/14/2018');
+    (component as any).resetDate();
+    expect((component as any).stockPickerForm.controls.dateTo.value).toEqual(
+      '1/14/2019'
+    );
+  });
+  it('should call resetDate() and dateTo < dateFrom', () => {
+    (component as any).stockPickerForm = formBuilder.group({
+      symbol: 'AAPL',
+      dateFrom: '1/14/2019',
+      dateTo: '1/14/2020'
+    });
+    (component as any).stockPickerForm.controls.dateTo.patchValue('1/14/2019');
+    (component as any).resetDate();
+    expect((component as any).stockPickerForm.controls.dateTo.value).toEqual(
+      '1/14/2019'
+    );
+  });
+
+  it('should call fetchQuote()', () => {
+    (component as any).stockPickerForm = formBuilder.group({
+      symbol: 'AAPL',
+      dateFrom: '1/14/2019',
+      dateTo: '1/14/2020'
+    });
+    spyOn((component as any).priceQuery, 'fetchQuote').and.returnValue(of({}));
+    (component as any).fetchQuote();
+    expect((component as any).priceQuery.fetchQuote).toBeCalled();
   });
 });

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { PriceQueryFacade } from '@coding-challenge/stocks/data-access-price-query';
 import { subYears } from 'date-fns';

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { PriceQueryFacade } from '@coding-challenge/stocks/data-access-price-query';
+import { subYears } from 'date-fns';
 
 @Component({
   selector: 'coding-challenge-stocks',
@@ -10,34 +11,44 @@ import { PriceQueryFacade } from '@coding-challenge/stocks/data-access-price-que
 export class StocksComponent implements OnInit {
   stockPickerForm: FormGroup;
   symbol: string;
-  period: string;
-
+  date = {
+    minFromDate: subYears(new Date(), 5), // since API support to take only 5 years back data (non-paid)
+    maxFromDate: new Date(),
+    minToDate: subYears(new Date(), 5),
+    maxToDate: new Date()
+  };
   quotes$ = this.priceQuery.priceQueries$;
 
-  timePeriods = [
-    { viewValue: 'All available data', value: 'max' },
-    { viewValue: 'Five years', value: '5y' },
-    { viewValue: 'Two years', value: '2y' },
-    { viewValue: 'One year', value: '1y' },
-    { viewValue: 'Year-to-date', value: 'ytd' },
-    { viewValue: 'Six months', value: '6m' },
-    { viewValue: 'Three months', value: '3m' },
-    { viewValue: 'One month', value: '1m' }
-  ];
+  constructor(private fb: FormBuilder, private priceQuery: PriceQueryFacade) {}
 
-  constructor(private fb: FormBuilder, private priceQuery: PriceQueryFacade) {
-    this.stockPickerForm = fb.group({
+  ngOnInit() {
+    this.stockLoad();
+  }
+
+  private stockLoad() {
+    this.createStockPickerForm();
+  }
+
+  private createStockPickerForm() {
+    this.stockPickerForm = this.fb.group({
       symbol: [null, Validators.required],
-      period: [null, Validators.required]
+      dateFrom: [null, Validators.required],
+      dateTo: [null, Validators.required]
     });
   }
 
-  ngOnInit() {}
+  public resetDate(): void {
+    const dateFrom = this.stockPickerForm.controls.dateFrom;
+    const dateTo = this.stockPickerForm.controls.dateTo;
+    if (dateFrom.value && dateTo.value && dateFrom.value > dateTo.value) {
+      dateTo.patchValue(dateFrom.value);
+    }
+  }
 
   fetchQuote() {
     if (this.stockPickerForm.valid) {
-      const { symbol, period } = this.stockPickerForm.value;
-      this.priceQuery.fetchQuote(symbol, period);
+      const { symbol, dateFrom, dateTo } = this.stockPickerForm.value;
+      this.priceQuery.fetchQuote(symbol, dateFrom, dateTo);
     }
   }
 }


### PR DESCRIPTION
**Task 3**

Changes done:

- Added the Angular material date picker and form validation error.
- There are two ways to pass the `period` to IEX API

1. Always passes `period` as `max` to IEX API, so that filtering can be applied to any date ranges within the all available data (limitation: date range cannot be passed to API and gives only the last 5 year data).
2. Other workaround is to find difference in years between `dateTo` and `dateFrom`. Then  conditionally with number of difference in years return the period.
- Added logic to filter the response for the date range and used `parse` method in `date-fns`. 
- Used `dataChange` event of `mat-datepicker` to reset date when date selected is "to" before "from" or "from" after "to".
- Fixed the bug to show the chart.
- Added / fixed the unit test case for Stock component.

**_Please note: This PR is created with only the minimal changes required to complete the business requirement._**


![image](https://user-images.githubusercontent.com/60087125/72795196-35302d00-3c63-11ea-9051-3a387b71feb1.png)

![Task3-testcase](https://user-images.githubusercontent.com/60087125/72745266-606c3b00-3bd5-11ea-911c-a90764d0a1a9.PNG)

