### PR TITLE
Feat proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,5 @@
 # T-Mobile Coding Challenge
 
-### Important! Read this First !
-
-Do **not** submit a pull request to this repository.  You PR wil be rejected and your submission ignored.
-To be safe **do not Fork** this repository, if you do you will be tempted to create a PR.
-
-To _properly_ submit a coding challenge you must:
-
-1. Create a blank (empty) repo in the public git service of your choice ( github, gitlab, bitbucket )
-2. Clone this repo to your local workstation
-3. Reset the remote origin to point to your newly created empty repo
-4. Push the master branch up to your repo
-
-5. make necessary changes
-6. push changes to your origin
-7. send address of your copy to t-mobile.
-
-We will review your copy online before and during your interview.
-
-
-# Stocks coding challenge
-
-## How to run the application
-
-There are two apps: `stocks` and `stocks-api`.
-
-- `stocks` is the front-end. It uses Angular 7 and Material. You can run this using `yarn serve:stocks`
-- `stocks-api` uses Hapi and has a very minimal implementation. You can start the API server with `yarn serve:stocks-api`
-
-A proxy has been set up in `stocks` to proxy calls to `locahost:3333` which is the port that the Hapi server listens on.
-
-> You need to register for a token here: https://iexcloud.io/cloud-login#/register/ Use this token in the `environment.ts` file for the `stocks` app.
-
-> The charting library is the Google charts API: https://developers.google.com/chart/
-
-## Problem statement
-
-[Original problem statement](https://github.com/tmobile/developer-kata/blob/master/puzzles/web-api/stock-broker.md)
-
-### Task 1
-
-Please provide a short code review of the base `master` branch:
-
-1. What is done well?
-2. What would you change?
-3. Are there any code smells or problematic implementations?
-
-> Make a PR to fix at least one of the issues that you identify
-
-### Task 2
-
-```
-Business requirement: As a user I should be able to type into
-the symbol field and make a valid time-frame selection so that
-the graph is refreshed automatically without needing to click a button.
-```
-
-_**Make a PR from the branch `feat_stock_typeahead` to `master` and provide a code review on this PR**_
-
-> Add comments to the PR. Focus on all items that you can see - this is a hypothetical example but let's treat it as a critical application. Then present these changes as another commit on the PR.
-
-### Task 3
-
-```
-Business requirement: As a user I want to choose custom dates
-so that I can view the trends within a specific period of time.
-```
-
-_**Implement this feature and make a PR from the branch `feat_custom_dates` to `master`.**_
-
-> Use the material date-picker component
-
-> We need two date-pickers: "from" and "to". The date-pickers should not allow selection of dates after the current day. "to" cannot be before "from" (selecting an invalid range should make both dates the same value)
-
 ### Task 4
 
 ```
@@ -84,3 +11,18 @@ same data. If a query is not in cache we should call-through to the API.
 _**Implement the solution and make a PR from the branch `feat_proxy_server` to `master`**_
 
 > It is important to get the implementation working before trying to organize and clean it up.
+
+_**Note: Added only the minimal changes to complete the technical requirement. Changes with `util` and test case fixes were done in Task 1**_
+
+### Changes done
+
+- Fixed the Google chart bug.
+- Separated the server logic using Hapi plugin, used register method to register the plugins created for the `stock-api` project. This way it will be logically separated and makes it more maintainable and resuable plugins. Added the logic to register multiple plugins.
+- Moved the environment constants `apiKey` and `apiURL` to `enviroment.ts` in `stocks-api`.
+- Created the HTTP service with `axios` to call the external API.
+- Used `catbox-memory` to implement the server-side caching mechanism. Also added an option to enable browser caching along with server-side.
+- Created a price query http service class to implement the HTTP call to Hapi server. This way the HTTP client is moved out of effects.
+
+### To Do
+
+- The Hapi folder and it's related files can be moved to `libs` folder to follow the monorepo structure and makes it resuable.

--- a/apps/stocks-api/src/app/plugin/plugin.constant.ts
+++ b/apps/stocks-api/src/app/plugin/plugin.constant.ts
@@ -1,0 +1,10 @@
+export const pluginConstant = {
+  API_PATH: {
+    STOCKS: 'beta/stock'
+  },
+  PLUGINS: {
+    STOCK_PLUGIN: {
+      NAME: 'stocksPlugin'
+    }
+  }
+};

--- a/apps/stocks-api/src/app/plugin/stocks.plugin.ts
+++ b/apps/stocks-api/src/app/plugin/stocks.plugin.ts
@@ -1,0 +1,58 @@
+import { HapiServerPlugin, HapiHttpRequestConfig } from '../../hapi/hapi.type';
+import { hapiConstant } from '../../hapi/hapi.constant';
+import { HapiHttpService } from '../../hapi/hapi-http.service';
+import { environment } from '../../environments/environment';
+import { pluginConstant } from './plugin.constant';
+
+export const stocksPlugin: HapiServerPlugin = {
+  name: pluginConstant.PLUGINS.STOCK_PLUGIN.NAME,
+  version: '1.0.0',
+  register: async function(server, options) {
+    server.method('getStocksPrice', getStocksPrice, {
+      cache: {
+        cache: hapiConstant.CACHE.NAME,
+        expiresIn: hapiConstant.CACHE.EXPIRES_IN, // caching for x secs
+        generateTimeout: hapiConstant.CACHE.TIMEOUT, // wait for x secs to timeout
+        getDecoratedValue: true
+      }
+    });
+    server.route({
+      method: 'GET',
+      path: '/chart/{symbol}/{period}',
+      handler: async function(request, h): Promise<any> {
+        try {
+          const { symbol, period } = request.params;
+          const { value, cached } = await server.methods.getStocksPrice(
+            symbol,
+            period
+          );
+          const response = h.response(value);
+          if (options.enableBrowserCache) {
+            const lastModified = cached ? new Date(cached.stored) : new Date();
+            response.header('Last-modified', lastModified.toUTCString());
+          }
+          return response;
+        } catch (error) {
+          return error;
+        }
+      }
+    });
+  }
+};
+
+async function getStocksPrice(symbol: string, period: string): Promise<any> {
+  return await HapiHttpService.callApi(createRequest(symbol, period));
+}
+
+function createRequest(symbol, period): HapiHttpRequestConfig {
+  const baseUrl = `${environment.apiURL}/${
+    pluginConstant.API_PATH.STOCKS
+  }/${symbol}/chart/${period}?token=${environment.apiKey}`;
+
+  return {
+    method: 'GET',
+    baseURL: baseUrl,
+    params: {},
+    timeout: hapiConstant.TIMEOUT
+  };
+}

--- a/apps/stocks-api/src/environments/environment.ts
+++ b/apps/stocks-api/src/environments/environment.ts
@@ -3,5 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiKey: 'Tsk_3fb186a8f9ca40fa9e06c87cecf2cc7a',
+  apiURL: 'https://sandbox.iexapis.com'
 };

--- a/apps/stocks-api/src/hapi/hapi-http.service.ts
+++ b/apps/stocks-api/src/hapi/hapi-http.service.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { HapiHttpRequestConfig } from './hapi.type';
+
+export class HapiHttpService {
+  public static async callApi(request: HapiHttpRequestConfig): Promise<any> {
+    try {
+      return await axios.request(request).then(response => {
+        return response.data;
+      });
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+}

--- a/apps/stocks-api/src/hapi/hapi.constant.ts
+++ b/apps/stocks-api/src/hapi/hapi.constant.ts
@@ -1,0 +1,13 @@
+export const hapiConstant = {
+  TIMEOUT: 10 * 1000,
+  HOST: 'localhost',
+  PORT: 3333,
+  CACHE: {
+    NAME: 'hapi_cache',
+    HOST: '127.0.0.1',
+    PORT: 6379,
+    PARTITION: 'hapi_cached_data',
+    EXPIRES_IN: 20 * 1000,
+    TIMEOUT: 10 * 1000
+  }
+};

--- a/apps/stocks-api/src/hapi/hapi.server.ts
+++ b/apps/stocks-api/src/hapi/hapi.server.ts
@@ -1,0 +1,56 @@
+import { Server } from 'hapi';
+import { HapiPluginConfig, HapiPlugin } from './hapi.type';
+import { hapiConstant } from './hapi.constant';
+import CatboxMemory from '@hapi/catbox-memory';
+import { environment } from '../environments/environment';
+
+const server = new Server({
+  port: hapiConstant.PORT,
+  host: hapiConstant.HOST,
+  debug: environment.production ? { request: ['error'] } : {},
+  cache: [
+    {
+      name: hapiConstant.CACHE.NAME,
+      provider: {
+        constructor: CatboxMemory,
+        options: {
+          partition: hapiConstant.CACHE.PARTITION,
+          host: hapiConstant.CACHE.HOST,
+          port: hapiConstant.CACHE.PORT,
+          database: 0
+        }
+      }
+    }
+  ]
+});
+
+export const start = async function(hapiPluginConfig: HapiPluginConfig) {
+  try {
+    // register multiple plugins
+    const plugins: Promise<void>[] = hapiPluginConfig.plugins.reduce(
+      (res: Promise<void>[], plugin: HapiPlugin) => {
+        let hapiPlugin = { plugin: plugin.hapiPlugin };
+
+        if (plugin.options) {
+          hapiPlugin = { ...hapiPlugin, ...{ options: plugin.options } };
+        }
+
+        if (plugin.routes) {
+          hapiPlugin = { ...hapiPlugin, ...{ routes: plugin.routes } };
+        }
+        res.push(server.register(hapiPlugin));
+        return res;
+      },
+      []
+    );
+
+    await Promise.all(plugins);
+
+    await server.start();
+
+    console.log('Server running on %s', server.info.uri);
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  }
+};

--- a/apps/stocks-api/src/hapi/hapi.type.ts
+++ b/apps/stocks-api/src/hapi/hapi.type.ts
@@ -1,0 +1,25 @@
+export type HapiPluginConfig = {
+  plugins: HapiPlugin[];
+};
+
+export interface HapiServerPlugin {
+  name: string;
+  version: string;
+  register(server: any, options: any): Promise<void>;
+}
+
+export interface HapiPlugin {
+  hapiPlugin: HapiServerPlugin;
+  options?: {};
+  routes?: { prefix: string };
+}
+
+export interface HapiHttpRequestConfig {
+  url?: string;
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  baseURL: string;
+  headers?: {};
+  params?: {};
+  data?: any;
+  timeout?: number;
+}

--- a/apps/stocks-api/src/main.ts
+++ b/apps/stocks-api/src/main.ts
@@ -1,32 +1,19 @@
-/**
- * This is not a production server yet!
- * This is only a minimal backend to get started.
- **/
-import { Server } from 'hapi';
+import { HapiPluginConfig } from './hapi/hapi.type';
+import { stocksPlugin } from './app/plugin/stocks.plugin';
+import { start } from './hapi/hapi.server';
 
-const init = async () => {
-  const server = new Server({
-    port: 3333,
-    host: 'localhost'
-  });
-
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler: (request, h) => {
-      return {
-        hello: 'world'
-      };
+const hapiPluginConfig: HapiPluginConfig = {
+  plugins: [
+    {
+      hapiPlugin: stocksPlugin,
+      options: {
+        enableBrowserCache: true
+      },
+      routes: {
+        prefix: '/api/v1.0/stocks'
+      }
     }
-  });
-
-  await server.start();
-  console.log('Server running on %s', server.info.uri);
+  ]
 };
 
-process.on('unhandledRejection', err => {
-  console.log(err);
-  process.exit(1);
-});
-
-init();
+start(hapiPluginConfig);

--- a/apps/stocks/src/environments/environment.ts
+++ b/apps/stocks/src/environments/environment.ts
@@ -1,13 +1,9 @@
-import { StocksAppConfig } from '@coding-challenge/stocks/data-access-app-config';
-
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment: StocksAppConfig = {
-  production: false,
-  apiKey: '',
-  apiURL: 'https://sandbox.iexapis.com'
+export const environment = {
+  production: false
 };
 
 /*

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,8 +1,8 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="data && data.length > 0"
   [title]="chart.title"
   [type]="chart.type"
-  [data]="chartData"
+  [data]="data"
   [columnNames]="chart.columnNames"
   [options]="chart.options"
 >

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.ts
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.ts
@@ -13,8 +13,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./chart.component.css']
 })
 export class ChartComponent implements OnInit {
-  @Input() data$: Observable<any>;
-  chartData: any;
+  @Input() data: any;
 
   chart: {
     title: string;
@@ -33,7 +32,5 @@ export class ChartComponent implements OnInit {
       columnNames: ['period', 'close'],
       options: { title: `Stock price`, width: '600', height: '400' }
     };
-
-    this.data$.subscribe(newData => (this.chartData = newData));
   }
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -1,9 +1,4 @@
-import { HttpClient } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
-import {
-  StocksAppConfig,
-  StocksAppConfigToken
-} from '@coding-challenge/stocks/data-access-app-config';
+import { Injectable } from '@angular/core';
 import { Effect } from '@ngrx/effects';
 import { DataPersistence } from '@nrwl/nx';
 import { map } from 'rxjs/operators';
@@ -15,6 +10,7 @@ import {
 } from './price-query.actions';
 import { PriceQueryPartialState } from './price-query.reducer';
 import { PriceQueryResponse } from './price-query.type';
+import { PriceQueryHttpService } from '../service/price-query-http.service';
 
 @Injectable()
 export class PriceQueryEffects {
@@ -22,12 +18,11 @@ export class PriceQueryEffects {
     PriceQueryActionTypes.FetchPriceQuery,
     {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
-        return this.httpClient
-          .get(
-            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
-              action.period
-            }?token=${this.env.apiKey}`
-          )
+        return this.priceQueryHttpService
+          .getStocksPrice({
+            symbol: action.symbol,
+            period: action.period
+          })
           .pipe(
             map(resp => new PriceQueryFetched(resp as PriceQueryResponse[]))
           );
@@ -40,8 +35,7 @@ export class PriceQueryEffects {
   );
 
   constructor(
-    @Inject(StocksAppConfigToken) private env: StocksAppConfig,
-    private httpClient: HttpClient,
-    private dataPersistence: DataPersistence<PriceQueryPartialState>
+    private dataPersistence: DataPersistence<PriceQueryPartialState>,
+    private readonly priceQueryHttpService: PriceQueryHttpService
   ) {}
 }

--- a/libs/stocks/data-access-price-query/src/lib/service/price-query-http.service.ts
+++ b/libs/stocks/data-access-price-query/src/lib/service/price-query-http.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class PriceQueryHttpService {
+  constructor(protected httpClient: HttpClient) {}
+
+  public getStocksPrice(params: any): Observable<any> {
+    return this.httpClient.get(
+      `/api/v1.0/stocks/chart/${params.symbol}/${params.period}`,
+      {
+        headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+      }
+    );
+  }
+}

--- a/libs/stocks/data-access-price-query/src/lib/stocks-data-access-price-query.module.ts
+++ b/libs/stocks/data-access-price-query/src/lib/stocks-data-access-price-query.module.ts
@@ -9,6 +9,7 @@ import {
   priceQueryReducer,
   PRICEQUERY_FEATURE_KEY
 } from './+state/price-query.reducer';
+import { PriceQueryHttpService } from './service/price-query-http.service';
 
 @NgModule({
   imports: [
@@ -17,6 +18,6 @@ import {
     StoreModule.forFeature(PRICEQUERY_FEATURE_KEY, priceQueryReducer),
     EffectsModule.forFeature([PriceQueryEffects])
   ],
-  providers: [PriceQueryFacade]
+  providers: [PriceQueryHttpService, PriceQueryFacade]
 })
 export class StocksDataAccessPriceQueryModule {}

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
@@ -32,4 +32,4 @@
   <button (click)="fetchQuote()" mat-raised-button>Go</button>
 </form>
 
-<coding-challenge-chart [data$]="quotes$"></coding-challenge-chart>
+<coding-challenge-chart [data]="quotes$ | async"></coding-challenge-chart>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@angular/platform-browser-dynamic": "^7.0.0",
     "@angular/platform-server": "^7.0.0",
     "@angular/router": "^7.0.0",
+    "@hapi/catbox-memory": "^5.0.0",
     "@nestjs/common": "5.5.0",
     "@nestjs/core": "5.5.0",
     "@ngrx/effects": "^7.4.0",


### PR DESCRIPTION
**Task 4**

Changes done:

- Completely moved the IEX cloud API call to Hapi JS.
- Separated the server side logic using Hapi plugin, used register method to register the plugins created for the `stock-api` project. This way it will be logically separated and makes it more maintainable and resuable plugins. Added the logic to register multiple plugins.
- Moved the environment constants `apiKey` and `apiURL` to `enviroment.ts` in `stocks-api`.
- Created the HTTP service with `axios` to call the external API.
- Used `catbox-memory` to implement the server-side caching mechanism. Also added an option to enable browser caching along with server-side. 
- Used Hapi `Server methods` for caching.
- Created a price query HTTP service class to implement the HTTP call to Hapi server. This way the HTTP client is moved out of effects.
- Fixed the bug to show the chart.

To do:

- The Hapi folder and it's related files can be moved to `libs` folder to follow the monorepo structure and makes it resuable.

**_Please note: This PR is created with only the minimal structural changes required to complete the technical requirement._**

![Task4-output](https://user-images.githubusercontent.com/60087125/72751780-89e19280-3be6-11ea-960e-8d23f954d533.png)
